### PR TITLE
yconverge kubectl passthrough + support converge-mode

### DIFF
--- a/e2e/converge_mode_test.go
+++ b/e2e/converge_mode_test.go
@@ -164,6 +164,114 @@ data:
 	}
 }
 
+// TestConvergeMode_DependencyGetsSameApplyPath proves that a
+// kustomization reached via a CUE dependency goes through the
+// same label-routed apply path as a direct -k target -- the
+// "convergeSingle is called for both" code path is otherwise
+// only verified by reading the source.
+//
+// Mirrors TestConvergeMode_ReplaceRecreates but through the dep
+// edge: a base directory whose ConfigMap carries
+// converge-mode=replace, imported by a dependent. Running
+// yconverge against the dependent twice and asserting the
+// base resource's UID changes between runs proves the
+// replace-mode delete-then-apply fired during the dep step.
+//
+// If the dep path silently bypassed the label routing (e.g. a
+// future "fast path" for deps that just shells out a single
+// `kubectl apply -k` per step), the UID would stay the same on
+// the second run and the assertion fails.
+func TestConvergeMode_DependencyGetsSameApplyPath(t *testing.T) {
+	setupCluster(t)
+	root := t.TempDir()
+	baseName := "convergetest-dep-base"
+	depName := "convergetest-dep-dependent"
+
+	// CUE module root + base directory carrying replace-mode.
+	writeKustomization(t, root, map[string]string{
+		"cue.mod/module.cue": `module: "yolean.se/test"
+language: { version: "v0.16.0" }
+`,
+		"base/kustomization.yaml": "resources:\n- cm.yaml\n",
+		"base/cm.yaml": fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  labels:
+    yolean.se/converge-mode: replace
+data:
+  marker: same
+`, baseName),
+		"base/yconverge.cue": `package base
+import "yolean.se/ystack/yconverge/verify"
+step: verify.#Step & { checks: [] }
+`,
+		"dependent/kustomization.yaml": "resources:\n- cm.yaml\n",
+		"dependent/cm.yaml": fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+data:
+  who: dependent
+`, depName),
+		"dependent/yconverge.cue": `package dependent
+import (
+  "yolean.se/ystack/yconverge/verify"
+  "yolean.se/test/base:base"
+)
+_dep: base.step
+step: verify.#Step & { checks: [] }
+`,
+		// Pure-CUE schema lives under cue.mod/pkg/, the standard
+		// CUE registry path, so the kustomize tree walker doesn't
+		// see it as a converge step (no kustomization.yaml beside
+		// it would have triggered "no kustomization file" anyway).
+		// The verify schema's import path is hardcoded to
+		// yolean.se/ystack/... in pkg/yconverge/cue.go's
+		// verifySchemaImport so the dep walker recognises it and
+		// skips it. Keep the same path here regardless of this
+		// fixture's own module name.
+		"cue.mod/pkg/yolean.se/ystack/yconverge/verify/schema.cue": `package verify
+#Step: { checks: [...{...}] }
+`,
+	})
+	t.Cleanup(func() {
+		for _, n := range []string{baseName, depName} {
+			_ = exec.Command("kubectl", "--context="+contextName, "delete", "configmap", n, "--ignore-not-found").Run()
+		}
+	})
+
+	depDir := filepath.Join(root, "dependent")
+	_, err := yconverge.Run(context.Background(), yconverge.Options{
+		Context:      contextName,
+		KustomizeDir: depDir,
+		SkipChecks:   true,
+	}, logger(t))
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	uid1 := kubectlGet(t, "configmap", baseName, "-o", "jsonpath={.metadata.uid}")
+	if uid1 == "" {
+		t.Fatalf("first run did not create the base ConfigMap %q via the dep edge", baseName)
+	}
+	if got := kubectlGet(t, "configmap", depName, "-o", "jsonpath={.data.who}"); got != "dependent" {
+		t.Fatalf("dependent did not land: data.who=%q", got)
+	}
+
+	_, err = yconverge.Run(context.Background(), yconverge.Options{
+		Context:      contextName,
+		KustomizeDir: depDir,
+		SkipChecks:   true,
+	}, logger(t))
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	uid2 := kubectlGet(t, "configmap", baseName, "-o", "jsonpath={.metadata.uid}")
+	if uid1 == uid2 {
+		t.Fatalf("base resource (replace-mode) was not recreated when applied via the dep edge; both runs returned UID %q -- dep path is bypassing label routing", uid1)
+	}
+}
+
 // TestConvergeMode_MixedKustomization is the smoke test for the
 // five-step plan running all five steps cleanly when a single
 // kustomize tree carries multiple modes plus an unlabelled

--- a/e2e/converge_mode_test.go
+++ b/e2e/converge_mode_test.go
@@ -1,0 +1,242 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Yolean/y-cluster/pkg/yconverge"
+)
+
+// writeKustomization drops a minimal kustomization tree at dir.
+// files maps relative path -> content. Each call replaces the
+// directory contents wholesale so a test can re-render a base
+// between Run() invocations.
+func writeKustomization(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("clear %s: %v", dir, err)
+	}
+	for rel, body := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", full, err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+}
+
+// kubectlGet runs `kubectl --context=ctxName get <args...>` and
+// returns trimmed stdout. Test helper so each assertion reads as
+// "what does the cluster currently say".
+func kubectlGet(t *testing.T, args ...string) string {
+	t.Helper()
+	full := append([]string{"--context=" + contextName, "get"}, args...)
+	cmd := exec.Command("kubectl", full...)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+clusterKubeconfig)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl get %v: %s: %v", args, out, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// runConverge runs yconverge.Run against a kustomization dir and
+// fails the test on error. Wraps the boilerplate every
+// converge-mode test would otherwise repeat.
+func runConverge(t *testing.T, dir string) {
+	t.Helper()
+	_, err := yconverge.Run(context.Background(), yconverge.Options{
+		Context:      contextName,
+		KustomizeDir: dir,
+		SkipChecks:   true, // these tests run their own assertions
+	}, logger(t))
+	if err != nil {
+		t.Fatalf("yconverge.Run %s: %v", dir, err)
+	}
+}
+
+// TestConvergeMode_CreateSkipsIfExists is the regression we
+// motivated this branch with: yolean.se/converge-mode=create
+// must hand the resource to `kubectl create --save-config`,
+// which means a re-run with edited source data leaves the
+// cluster value alone (skip-if-exists).
+//
+// Before this branch's kubectl-shellouts work, every label was
+// silently coerced to server-side-apply force, and the second
+// run would have updated the data.
+func TestConvergeMode_CreateSkipsIfExists(t *testing.T) {
+	setupCluster(t)
+	name := "convergetest-cm-create"
+	dir := filepath.Join(t.TempDir(), "k")
+
+	// First render: foo=original.
+	writeKustomization(t, dir, map[string]string{
+		"kustomization.yaml": "resources:\n- cm.yaml\n",
+		"cm.yaml": fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  labels:
+    yolean.se/converge-mode: create
+data:
+  foo: original
+`, name),
+	})
+	t.Cleanup(func() {
+		_ = exec.Command("kubectl", "--context="+contextName, "delete", "configmap", name, "--ignore-not-found").Run()
+	})
+
+	runConverge(t, dir)
+	if got := kubectlGet(t, "configmap", name, "-o", "jsonpath={.data.foo}"); got != "original" {
+		t.Fatalf("after first run: foo=%q want %q", got, "original")
+	}
+
+	// Second render: foo=changed. create-mode means create-skip-
+	// if-exists, so the cluster value should NOT update.
+	writeKustomization(t, dir, map[string]string{
+		"kustomization.yaml": "resources:\n- cm.yaml\n",
+		"cm.yaml": fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  labels:
+    yolean.se/converge-mode: create
+data:
+  foo: changed
+`, name),
+	})
+
+	runConverge(t, dir)
+	if got := kubectlGet(t, "configmap", name, "-o", "jsonpath={.data.foo}"); got != "original" {
+		t.Fatalf("create-mode must skip-if-exists; foo=%q want %q (would have flipped to 'changed' under apply semantics)", got, "original")
+	}
+}
+
+// TestConvergeMode_ReplaceRecreates: yolean.se/converge-mode=replace
+// runs `kubectl delete` followed by the plain-apply step, so
+// the resource's UID changes between runs even when the spec
+// hasn't changed. This is what makes the mode usable for Jobs
+// (whose spec.template is immutable on a same-name re-apply).
+func TestConvergeMode_ReplaceRecreates(t *testing.T) {
+	setupCluster(t)
+	name := "convergetest-cm-replace"
+	dir := filepath.Join(t.TempDir(), "k")
+
+	cm := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  labels:
+    yolean.se/converge-mode: replace
+data:
+  marker: same
+`, name)
+	writeKustomization(t, dir, map[string]string{
+		"kustomization.yaml": "resources:\n- cm.yaml\n",
+		"cm.yaml":            cm,
+	})
+	t.Cleanup(func() {
+		_ = exec.Command("kubectl", "--context="+contextName, "delete", "configmap", name, "--ignore-not-found").Run()
+	})
+
+	runConverge(t, dir)
+	uid1 := kubectlGet(t, "configmap", name, "-o", "jsonpath={.metadata.uid}")
+	if uid1 == "" {
+		t.Fatal("first run did not create the ConfigMap")
+	}
+
+	runConverge(t, dir)
+	uid2 := kubectlGet(t, "configmap", name, "-o", "jsonpath={.metadata.uid}")
+	if uid2 == "" {
+		t.Fatal("second run lost the ConfigMap")
+	}
+	if uid1 == uid2 {
+		t.Fatalf("replace-mode should recreate the resource (UID change); both runs returned %q", uid1)
+	}
+}
+
+// TestConvergeMode_MixedKustomization is the smoke test for the
+// five-step plan running all five steps cleanly when a single
+// kustomize tree carries multiple modes plus an unlabelled
+// resource. Asserts each resource lands; the per-mode behaviour
+// is covered by the dedicated tests above.
+//
+// Importantly this also exercises the "no objects passed to
+// <verb>" stderr tolerance: we only label a subset of modes,
+// and the un-used mode steps must not error the run out.
+func TestConvergeMode_MixedKustomization(t *testing.T) {
+	setupCluster(t)
+	dir := filepath.Join(t.TempDir(), "k")
+
+	body := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: convergetest-mixed-create
+  labels:
+    yolean.se/converge-mode: create
+data:
+  who: create-mode
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: convergetest-mixed-ssforce
+  labels:
+    yolean.se/converge-mode: serverside-force
+data:
+  who: ssforce-mode
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: convergetest-mixed-ss
+  labels:
+    yolean.se/converge-mode: serverside
+data:
+  who: ss-mode
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: convergetest-mixed-plain
+data:
+  who: plain-mode
+`
+	writeKustomization(t, dir, map[string]string{
+		"kustomization.yaml": "resources:\n- cms.yaml\n",
+		"cms.yaml":           body,
+	})
+	t.Cleanup(func() {
+		for _, n := range []string{
+			"convergetest-mixed-create",
+			"convergetest-mixed-ssforce",
+			"convergetest-mixed-ss",
+			"convergetest-mixed-plain",
+		} {
+			_ = exec.Command("kubectl", "--context="+contextName, "delete", "configmap", n, "--ignore-not-found").Run()
+		}
+	})
+
+	runConverge(t, dir)
+
+	for name, wantValue := range map[string]string{
+		"convergetest-mixed-create":  "create-mode",
+		"convergetest-mixed-ssforce": "ssforce-mode",
+		"convergetest-mixed-ss":      "ss-mode",
+		"convergetest-mixed-plain":   "plain-mode",
+	} {
+		got := kubectlGet(t, "configmap", name, "-o", "jsonpath={.data.who}")
+		if got != wantValue {
+			t.Errorf("%s: data.who=%q want %q", name, got, wantValue)
+		}
+	}
+}

--- a/e2e/converge_output_test.go
+++ b/e2e/converge_output_test.go
@@ -1,0 +1,110 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestConvergeMode_OutputForwardsKubectlLines is the third leg of
+// the converge-mode coverage plan: prove that kubectl's per-
+// resource output reaches the user verbatim. The whole point of
+// switching from client-go SSA to kubectl shellouts was so a
+// developer running `y-cluster yconverge` (or `kubectl yconverge`)
+// sees the same line shapes they'd see running kubectl directly --
+// the structured zap "applied" lines the previous client-go path
+// emitted are not the same UX.
+//
+// We run the actual binary as a subprocess and capture its
+// stdout (you can't capture os.Stdout from inside the test binary
+// because pkg/yconverge writes there directly). Three assertions:
+//
+//   1. The plain-apply step (no label) produces
+//      "configmap/<name> created" -- the verb kubectl client-side
+//      apply emits on first run.
+//   2. The serverside-force step's resource produces
+//      "configmap/<name> serverside-applied" -- distinct verb
+//      because that step uses --server-side.
+//   3. "No resources found" must NOT appear: kubectl delete
+//      prints that to stdout when the replace-mode selector
+//      matches nothing (a fresh cluster, no replace label in the
+//      fixture), and the wrapper's stdout-suppress list catches
+//      it so a default yconverge run doesn't surface that noise.
+//
+// If any assertion fails, the wrapper has regressed: either the
+// per-resource lines are being captured-and-dropped, or the
+// suppression for empty-selector-match lines has loosened.
+func TestConvergeMode_OutputForwardsKubectlLines(t *testing.T) {
+	setupCluster(t)
+	bin := buildServeBinary(t)
+
+	dir := filepath.Join(t.TempDir(), "k")
+	plainName := "convergeout-plain"
+	forceName := "convergeout-ssforce"
+	body := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+data:
+  x: "1"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  labels:
+    yolean.se/converge-mode: serverside-force
+data:
+  x: "1"
+`, plainName, forceName)
+	writeKustomization(t, dir, map[string]string{
+		"kustomization.yaml": "resources:\n- cms.yaml\n",
+		"cms.yaml":           body,
+	})
+	t.Cleanup(func() {
+		for _, n := range []string{plainName, forceName} {
+			_ = exec.Command("kubectl", "--context="+contextName, "delete", "configmap", n, "--ignore-not-found").Run()
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin,
+		"yconverge", "--context="+contextName, "-k", dir, "--skip-checks")
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+clusterKubeconfig)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("y-cluster yconverge: %v\noutput:\n%s", err, out)
+	}
+	got := string(out)
+
+	// Plain-apply step (kubectl apply, no --server-side, on the
+	// negative-selector fall-through) prints "created" on first
+	// run. This is the normal kubectl client-side-apply verb.
+	plainLine := fmt.Sprintf("configmap/%s created", plainName)
+	if !strings.Contains(got, plainLine) {
+		t.Errorf("output missing %q\nfull output:\n%s", plainLine, got)
+	}
+
+	// serverside-force step uses kubectl apply --server-side
+	// --force-conflicts; verb is "serverside-applied".
+	forceLine := fmt.Sprintf("configmap/%s serverside-applied", forceName)
+	if !strings.Contains(got, forceLine) {
+		t.Errorf("output missing %q\nfull output:\n%s", forceLine, got)
+	}
+
+	// "No resources found" is what kubectl delete prints (to stdout,
+	// exit 0) when the replace-mode selector matches nothing. The
+	// wrapper's stdout-suppress list is supposed to drop it so a
+	// vanilla yconverge run isn't noisy.
+	if strings.Contains(got, "No resources found") {
+		t.Errorf("output should not surface kubectl delete's empty-match line\nfull output:\n%s", got)
+	}
+}

--- a/e2e/converge_progress_test.go
+++ b/e2e/converge_progress_test.go
@@ -1,0 +1,205 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestConvergeProgress_DepAndTargetHeaders pins the four progress
+// header shapes against a real run:
+//
+//   - yconverge dependency <relpath>   -- before each dep
+//   - yconverge converge-mode=<mode>   -- before non-empty mode buckets
+//   - yconverge target <relpath>       -- before the final step (only when deps ran)
+//   - yconverge check N/total <kind>   -- before each check
+//
+// Builds a CUE module on disk with a base/ that carries
+// converge-mode=replace + a dependent that depends on it and
+// declares one exec check. Runs the binary, captures stdout,
+// asserts the headers appear in the expected order.
+func TestConvergeProgress_DepAndTargetHeaders(t *testing.T) {
+	setupCluster(t)
+	bin := buildServeBinary(t)
+
+	root := t.TempDir()
+	baseName := "convergeprogress-base"
+	depName := "convergeprogress-dependent"
+	writeKustomization(t, root, map[string]string{
+		"cue.mod/module.cue": `module: "yolean.se/test"
+language: { version: "v0.16.0" }
+`,
+		// Verify schema lives at the canonical ystack path; see
+		// pkg/yconverge/cue.go's verifySchemaImport.
+		"cue.mod/pkg/yolean.se/ystack/yconverge/verify/schema.cue": `package verify
+#Step: { checks: [...{...}] }
+`,
+		"base/kustomization.yaml": "resources:\n- cm.yaml\n",
+		"base/cm.yaml": fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  labels:
+    yolean.se/converge-mode: replace
+data:
+  marker: same
+`, baseName),
+		"base/yconverge.cue": `package base
+import "yolean.se/ystack/yconverge/verify"
+step: verify.#Step & { checks: [] }
+`,
+		"dependent/kustomization.yaml": "resources:\n- cm.yaml\n",
+		"dependent/cm.yaml": fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+data:
+  who: dependent
+`, depName),
+		"dependent/yconverge.cue": `package dependent
+import (
+  "yolean.se/ystack/yconverge/verify"
+  "yolean.se/test/base:base"
+)
+_dep: base.step
+step: verify.#Step & { checks: [{
+  kind: "exec"
+  command: "true"
+  description: "noop check that always succeeds"
+  timeout: "5s"
+}] }
+`,
+	})
+	t.Cleanup(func() {
+		for _, n := range []string{baseName, depName} {
+			_ = exec.Command("kubectl", "--context="+contextName, "delete", "configmap", n, "--ignore-not-found").Run()
+		}
+	})
+
+	depDir := filepath.Join(root, "dependent")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin,
+		"yconverge", "--context="+contextName, "-k", depDir)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+clusterKubeconfig)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("y-cluster yconverge: %v\noutput:\n%s", err, out)
+	}
+	got := string(out)
+
+	wants := []string{
+		"yconverge dependency base",
+		"yconverge converge-mode=replace",
+		"yconverge target dependent",
+		"yconverge check 1/1 exec",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("missing progress line %q\nfull output:\n%s", w, got)
+		}
+	}
+
+	// Order matters: dependency before target, target before check.
+	depIdx := strings.Index(got, "yconverge dependency base")
+	tgtIdx := strings.Index(got, "yconverge target dependent")
+	chkIdx := strings.Index(got, "yconverge check 1/1 exec")
+	if !(depIdx < tgtIdx && tgtIdx < chkIdx) {
+		t.Errorf("progress lines out of order: dep=%d target=%d check=%d\nfull output:\n%s",
+			depIdx, tgtIdx, chkIdx, got)
+	}
+}
+
+// TestConvergeProgress_NoDepsNoTargetHeader: a run without
+// dependencies must NOT print "yconverge target" -- the user
+// already knows what they passed via -k. Only the dep+target
+// case earns the symmetric header.
+func TestConvergeProgress_NoDepsNoTargetHeader(t *testing.T) {
+	setupCluster(t)
+	bin := buildServeBinary(t)
+
+	dir := filepath.Join(t.TempDir(), "k")
+	name := "convergeprogress-nodeps"
+	writeKustomization(t, dir, map[string]string{
+		"kustomization.yaml": "resources:\n- cm.yaml\n",
+		"cm.yaml": fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+data:
+  x: "1"
+`, name),
+	})
+	t.Cleanup(func() {
+		_ = exec.Command("kubectl", "--context="+contextName, "delete", "configmap", name, "--ignore-not-found").Run()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin,
+		"yconverge", "--context="+contextName, "-k", dir, "--skip-checks")
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+clusterKubeconfig)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("y-cluster yconverge: %v\noutput:\n%s", err, out)
+	}
+	got := string(out)
+
+	if strings.Contains(got, "yconverge dependency") {
+		t.Errorf("no-deps run must not print 'yconverge dependency':\n%s", got)
+	}
+	if strings.Contains(got, "yconverge target") {
+		t.Errorf("no-deps run must not print 'yconverge target':\n%s", got)
+	}
+	// kubectl's per-resource line should still be there.
+	if !strings.Contains(got, fmt.Sprintf("configmap/%s created", name)) {
+		t.Errorf("kubectl per-resource line missing:\n%s", got)
+	}
+}
+
+// TestConvergeProgress_EmptyModeNoHeader: a kustomization that
+// uses no labelled modes (all unlabelled, plain apply) must NOT
+// print any "yconverge converge-mode=" line. The header is
+// suppressed alongside the empty-bucket kubectl output.
+func TestConvergeProgress_EmptyModeNoHeader(t *testing.T) {
+	setupCluster(t)
+	bin := buildServeBinary(t)
+
+	dir := filepath.Join(t.TempDir(), "k")
+	name := "convergeprogress-empty"
+	writeKustomization(t, dir, map[string]string{
+		"kustomization.yaml": "resources:\n- cm.yaml\n",
+		"cm.yaml": fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+data:
+  x: "1"
+`, name),
+	})
+	t.Cleanup(func() {
+		_ = exec.Command("kubectl", "--context="+contextName, "delete", "configmap", name, "--ignore-not-found").Run()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin,
+		"yconverge", "--context="+contextName, "-k", dir, "--skip-checks")
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+clusterKubeconfig)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("y-cluster yconverge: %v\noutput:\n%s", err, out)
+	}
+	got := string(out)
+
+	if strings.Contains(got, "yconverge converge-mode=") {
+		t.Errorf("unlabelled run must not print any 'yconverge converge-mode=' header:\n%s", got)
+	}
+}

--- a/pkg/k8sapply/k8sapply.go
+++ b/pkg/k8sapply/k8sapply.go
@@ -178,7 +178,7 @@ func applyOne(ctx context.Context, dyn dynamic.Interface, mapper meta.RESTMapper
 		// apierrors.IsConflict / IsForbidden / IsServerTimeout.
 		return fmt.Errorf("apply %s/%s: %w", gvk.Kind, obj.GetName(), err)
 	}
-	logger.Info("applied",
+	logger.Debug("applied",
 		zap.String("kind", gvk.Kind),
 		zap.String("name", obj.GetName()),
 		zap.String("namespace", ns),

--- a/pkg/provision/qemu/stopvm_test.go
+++ b/pkg/provision/qemu/stopvm_test.go
@@ -108,11 +108,14 @@ func TestStopVM_EscalatesToSIGKILL(t *testing.T) {
 	withGraceTimeouts(t, 1*time.Second, 5*time.Second)
 
 	// bash trap '' TERM ignores SIGTERM until the shell exits; only
-	// SIGKILL will reap it. `sleep infinity` keeps it alive without
-	// burning CPU. exec sleep so the bash shell is replaced with the
-	// process we want to outlive SIGTERM (otherwise SIGTERM would go
-	// to bash, which forwards/handles signals differently).
-	cmd := startReapableChild(t, "bash", "-c", "trap '' TERM; sleep infinity")
+	// SIGKILL will reap it. A long finite sleep keeps it alive
+	// without burning CPU. We avoid `sleep infinity` because that's
+	// a GNU coreutils extension -- macOS BSD sleep rejects it with
+	// "invalid time interval" and bash exits before the test has a
+	// chance to send SIGTERM, making the test pass-by-coincidence
+	// (returning fast through the "process is already dead" branch
+	// of stopVM). 60s is plenty for the test's grace timeouts.
+	cmd := startReapableChild(t, "bash", "-c", "trap '' TERM; sleep 60")
 
 	// Give bash a moment to install the trap before we ask stopVM
 	// to send SIGTERM. Without this the signal can race the trap

--- a/pkg/yconverge/checks.go
+++ b/pkg/yconverge/checks.go
@@ -10,7 +10,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/Yolean/y-cluster/pkg/k8swait"
 )
 
 // Check represents a single post-apply verification step.
@@ -81,7 +80,7 @@ func (r *CheckRunner) runWait(ctx context.Context, check Check, ns string, timeo
 		zap.String("resource", check.Resource),
 		zap.String("description", desc),
 	)
-	if err := k8swait.Wait(ctx, r.Context, check.Resource, ns, check.For, timeout); err != nil {
+	if err := kubectlWait(ctx, r.Context, check.Resource, ns, check.For, timeout); err != nil {
 		r.Logger.Error("wait check failed",
 			zap.String("resource", check.Resource),
 			zap.String("for", check.For),
@@ -102,7 +101,7 @@ func (r *CheckRunner) runRollout(ctx context.Context, check Check, ns string, ti
 		zap.String("resource", check.Resource),
 		zap.String("description", desc),
 	)
-	if err := k8swait.RolloutStatus(ctx, r.Context, check.Resource, ns, timeout); err != nil {
+	if err := kubectlRolloutStatus(ctx, r.Context, check.Resource, ns, timeout); err != nil {
 		r.Logger.Error("rollout check failed",
 			zap.String("resource", check.Resource),
 			zap.Error(err),

--- a/pkg/yconverge/checks.go
+++ b/pkg/yconverge/checks.go
@@ -76,7 +76,7 @@ func (r *CheckRunner) runWait(ctx context.Context, check Check, ns string, timeo
 	if desc == "" {
 		desc = fmt.Sprintf("wait %s %s", check.Resource, check.For)
 	}
-	r.Logger.Info("check",
+	r.Logger.Debug("check",
 		zap.String("kind", "wait"),
 		zap.String("resource", check.Resource),
 		zap.String("description", desc),
@@ -97,7 +97,7 @@ func (r *CheckRunner) runRollout(ctx context.Context, check Check, ns string, ti
 	if desc == "" {
 		desc = fmt.Sprintf("rollout %s", check.Resource)
 	}
-	r.Logger.Info("check",
+	r.Logger.Debug("check",
 		zap.String("kind", "rollout"),
 		zap.String("resource", check.Resource),
 		zap.String("description", desc),
@@ -113,7 +113,7 @@ func (r *CheckRunner) runRollout(ctx context.Context, check Check, ns string, ti
 }
 
 func (r *CheckRunner) runExec(ctx context.Context, check Check, timeout time.Duration) error {
-	r.Logger.Info("check",
+	r.Logger.Debug("check",
 		zap.String("kind", "exec"),
 		zap.String("description", check.Description),
 	)

--- a/pkg/yconverge/checks.go
+++ b/pkg/yconverge/checks.go
@@ -5,11 +5,12 @@ package yconverge
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"time"
 
 	"go.uber.org/zap"
-
 )
 
 // Check represents a single post-apply verification step.
@@ -31,11 +32,37 @@ type CheckRunner struct {
 	Context   string // Kubernetes context name
 	Namespace string // resolved namespace
 	Logger    *zap.Logger
+	// Stdout receives the per-check progress headers ("yconverge
+	// check N/total <kind>") and forwarded kubectl output. nil ->
+	// os.Stdout. Distinct from Logger (the diagnostic channel)
+	// because these lines are part of the user-facing UI, not
+	// a log.
+	Stdout io.Writer
+}
+
+func (r *CheckRunner) progressOut() io.Writer {
+	if r.Stdout != nil {
+		return r.Stdout
+	}
+	return os.Stdout
 }
 
 // RunAll executes checks in order. A failing check stops execution.
+//
+// Each check emits a progress header before running:
+//
+//	yconverge check N/total <kind>
+//
+// where N is 1-indexed. The header is written before the check
+// runs (so a hanging or slow check is visible by the header
+// landing without follow-up output) and is silent on success
+// past whatever kubectl wait / rollout-status / the exec command
+// itself prints.
 func (r *CheckRunner) RunAll(ctx context.Context, checks []Check) error {
+	out := r.progressOut()
+	total := len(checks)
 	for i, check := range checks {
+		fmt.Fprintf(out, "yconverge check %d/%d %s\n", i+1, total, check.Kind)
 		if err := r.runOne(ctx, check); err != nil {
 			return &CheckError{
 				Index: i,
@@ -80,7 +107,7 @@ func (r *CheckRunner) runWait(ctx context.Context, check Check, ns string, timeo
 		zap.String("resource", check.Resource),
 		zap.String("description", desc),
 	)
-	if err := kubectlWait(ctx, r.Context, check.Resource, ns, check.For, timeout); err != nil {
+	if err := kubectlWait(ctx, r.progressOut(), r.Context, check.Resource, ns, check.For, timeout); err != nil {
 		r.Logger.Error("wait check failed",
 			zap.String("resource", check.Resource),
 			zap.String("for", check.For),
@@ -101,7 +128,7 @@ func (r *CheckRunner) runRollout(ctx context.Context, check Check, ns string, ti
 		zap.String("resource", check.Resource),
 		zap.String("description", desc),
 	)
-	if err := kubectlRolloutStatus(ctx, r.Context, check.Resource, ns, timeout); err != nil {
+	if err := kubectlRolloutStatus(ctx, r.progressOut(), r.Context, check.Resource, ns, timeout); err != nil {
 		r.Logger.Error("rollout check failed",
 			zap.String("resource", check.Resource),
 			zap.Error(err),

--- a/pkg/yconverge/kubectl.go
+++ b/pkg/yconverge/kubectl.go
@@ -1,0 +1,120 @@
+package yconverge
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// runKubectl executes `kubectl <args...>` with stdout / stderr
+// forwarded to the host process so the user sees verbatim what
+// kubectl says -- the line shapes (`<kind>/<name> serverside-applied`,
+// `deployment.apps/foo condition met`, etc.) developers already
+// know from running kubectl directly.
+//
+// Output is intentionally NOT captured: the callers don't post-
+// process it (in contrast to e.g. cluster.RunCtr where we forward
+// a stream into the user's pipe). Forward-without-capture keeps
+// the wrapper invisible -- a `kubectl yconverge` invocation looks
+// the same as the underlying kubectl invocation modulo the
+// `kubectl` prefix.
+//
+// Errors carry the exit code and the args so a failure surfaces
+// "kubectl apply -k /tmp/xyz: exit status 1" -- enough for a
+// scripted caller to act, while the actual diagnostic text is
+// already on the user's terminal from kubectl's stderr.
+func runKubectl(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("kubectl %s: %w", argSummary(args), err)
+	}
+	return nil
+}
+
+// argSummary returns a short description of an argv for error
+// messages. The full argv can be long (kustomize paths, jsonpath
+// specs); we keep the first three meaningful entries so the
+// reader sees `kubectl apply --server-side ...` rather than the
+// whole string.
+func argSummary(args []string) string {
+	keep := args
+	if len(keep) > 3 {
+		keep = keep[:3]
+	}
+	out := ""
+	for i, a := range keep {
+		if i > 0 {
+			out += " "
+		}
+		out += a
+	}
+	if len(args) > len(keep) {
+		out += " ..."
+	}
+	return out
+}
+
+// kubectlApply runs `kubectl --context=<...> apply --server-side
+// --force-conflicts --field-manager=y-cluster -k <dir>` against
+// the configured context. The flag set matches what
+// pkg/k8sapply.Apply does internally so the wire-level effect is
+// identical -- only the developer-visible output differs.
+//
+// --dry-run=server forwards through; the bash plugin's
+// "client mode is rejected" rule is preserved because kubectl
+// itself rejects --dry-run=client with --server-side.
+func kubectlApply(ctx context.Context, opts Options) error {
+	args := []string{
+		"--context=" + opts.Context,
+		"apply",
+		"--server-side",
+		"--force-conflicts",
+		"--field-manager=y-cluster",
+		"-k", opts.KustomizeDir,
+	}
+	if opts.DryRun == "server" {
+		args = append(args, "--dry-run=server")
+	}
+	return runKubectl(ctx, args...)
+}
+
+// kubectlWait runs `kubectl --context=<...> wait <resource> -n <ns>
+// --for=<forSpec> --timeout=<timeout>`. forSpec is the same
+// `condition=...` / `jsonpath=...` / `delete` form kubectl wait
+// accepts -- yconverge.cue's Check.For is already in that shape.
+//
+// Empty namespace omits `-n`, matching kubectl wait's "use the
+// context's default namespace" behaviour. Cluster-scoped kinds
+// pass empty here.
+func kubectlWait(ctx context.Context, contextName, resource, namespace, forSpec string, timeout time.Duration) error {
+	args := []string{
+		"--context=" + contextName,
+		"wait", resource,
+		"--for=" + forSpec,
+		"--timeout=" + timeout.String(),
+	}
+	if namespace != "" {
+		args = append(args, "-n", namespace)
+	}
+	return runKubectl(ctx, args...)
+}
+
+// kubectlRolloutStatus runs `kubectl --context=<...> rollout
+// status <resource> -n <ns> --timeout=<timeout>`. resource is
+// already in the `<kind>/<name>` form the bash plugin used.
+func kubectlRolloutStatus(ctx context.Context, contextName, resource, namespace string, timeout time.Duration) error {
+	args := []string{
+		"--context=" + contextName,
+		"rollout", "status", resource,
+		"--timeout=" + timeout.String(),
+	}
+	if namespace != "" {
+		args = append(args, "-n", namespace)
+	}
+	return runKubectl(ctx, args...)
+}

--- a/pkg/yconverge/kubectl.go
+++ b/pkg/yconverge/kubectl.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -18,14 +19,22 @@ import (
 const ConvergeModeLabel = "yolean.se/converge-mode"
 
 // runKubectlStreaming executes `kubectl <args...>` with stdin /
-// stdout / stderr forwarded to the host process. Output is not
-// captured -- the user sees verbatim what kubectl says, which is
-// the line shape (`<kind>/<name> serverside-applied`,
-// `... condition met`) developers already know from running
-// kubectl directly.
-func runKubectlStreaming(ctx context.Context, args ...string) error {
+// stdout / stderr forwarded. Output is not captured -- the user
+// sees verbatim what kubectl says (`<kind>/<name> condition met`
+// from `kubectl wait`, etc.). Used for the wait / rollout-status
+// paths where kubectl's own progress output is the answer the
+// user wants.
+//
+// progress is the writer kubectl's stdout goes to (typically
+// opts.progressOut() to keep the four "yconverge ..." headers
+// and the kubectl lines on the same sink). nil falls back to
+// os.Stdout so callers that don't care can pass nil.
+func runKubectlStreaming(ctx context.Context, progress io.Writer, args ...string) error {
+	if progress == nil {
+		progress = os.Stdout
+	}
 	cmd := exec.CommandContext(ctx, "kubectl", args...)
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = progress
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {
@@ -34,29 +43,28 @@ func runKubectlStreaming(ctx context.Context, args ...string) error {
 	return nil
 }
 
-// runKubectlTolerant runs `kubectl <args...>` and suppresses
-// "expected idempotent" output. Two slots:
+// runApplyInvocation runs one of a group's kubectl invocations,
+// captures its stdout into out (so the caller can decide whether
+// to forward it after seeing all invocations in the group), and
+// surfaces stderr. The two tolerance slots match the bash
+// plugin's pattern:
 //
 //   - stderrTolerate: if kubectl exits non-zero AND its stderr
-//     matches one of these substrings, treat as success and
+//     contains one of these substrings, treat as success and
 //     drop the stderr text. Used for "no objects passed to
 //     <verb>" (empty selector match) and "AlreadyExists" (re-run
 //     of a create-mode resource).
-//   - stdoutSuppress: if kubectl's stdout matches one of these
-//     substrings, drop the stdout text from the user's view.
-//     Used for `kubectl delete`'s "No resources found" line --
-//     it lands on stdout with exit 0, so without suppression a
-//     vanilla yconverge run prints noise even when there's
-//     nothing for the delete step to do.
+//   - stdoutSuppress: if kubectl's stdout contains one of these
+//     substrings, drop the stdout entirely. Used for
+//     `kubectl delete`'s "No resources found" line -- lands on
+//     stdout with exit 0 so a vanilla yconverge run would surface
+//     it as noise without suppression.
 //
-// Both lists default to nil. stdout that doesn't match a
-// suppress pattern is forwarded verbatim so the kubectl-style
-// per-resource lines (`<kind>/<name> serverside-applied` etc.)
-// reach the user. stderr that doesn't match a tolerate pattern
-// is forwarded too, before the error propagates, so a real
+// stderr that doesn't match a tolerate pattern is forwarded to
+// the user's stderr before the error propagates, so a real
 // kubectl diagnostic isn't swallowed.
-func runKubectlTolerant(ctx context.Context, stderrTolerate, stdoutSuppress []string, args ...string) error {
-	cmd := exec.CommandContext(ctx, "kubectl", args...)
+func runApplyInvocation(ctx context.Context, step applyStep, out io.Writer) error {
+	cmd := exec.CommandContext(ctx, "kubectl", step.args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -64,14 +72,14 @@ func runKubectlTolerant(ctx context.Context, stderrTolerate, stdoutSuppress []st
 
 	if sout := stdout.String(); sout != "" {
 		suppress := false
-		for _, p := range stdoutSuppress {
+		for _, p := range step.stdoutSuppress {
 			if strings.Contains(sout, p) {
 				suppress = true
 				break
 			}
 		}
 		if !suppress {
-			_, _ = os.Stdout.WriteString(sout)
+			_, _ = out.Write([]byte(sout))
 		}
 	}
 
@@ -79,13 +87,13 @@ func runKubectlTolerant(ctx context.Context, stderrTolerate, stdoutSuppress []st
 		return nil
 	}
 	msg := stderr.String()
-	for _, t := range stderrTolerate {
+	for _, t := range step.stderrTolerate {
 		if strings.Contains(msg, t) {
 			return nil
 		}
 	}
 	_, _ = os.Stderr.Write([]byte(msg))
-	return fmt.Errorf("kubectl %s: %w", argSummary(args), err)
+	return fmt.Errorf("kubectl %s: %w", argSummary(step.args), err)
 }
 
 // argSummary returns a short description of an argv for error
@@ -112,51 +120,91 @@ func argSummary(args []string) string {
 }
 
 // kubectlApply renders the kustomize tree at opts.KustomizeDir and
-// applies its resources via five label-routed kubectl invocations,
-// matching the bash kubectl-yconverge plugin (90e8923) one-for-one:
+// applies its resources via label-routed kubectl invocations,
+// matching the bash kubectl-yconverge plugin (90e8923):
 //
 //  1. yolean.se/converge-mode=create       -> kubectl create --save-config
-//  2. yolean.se/converge-mode=replace      -> kubectl delete (followed by step 5's apply)
+//  2. yolean.se/converge-mode=replace      -> kubectl delete + kubectl apply (re-create)
 //  3. yolean.se/converge-mode=serverside-force -> kubectl apply --server-side --force-conflicts
 //  4. yolean.se/converge-mode=serverside   -> kubectl apply --server-side
-//  5. (no label, or label=replace)         -> kubectl apply
+//  5. (unlabelled)                         -> kubectl apply
 //
-// Step 5's selector excludes the labels handled in 1, 3, 4 -- the
-// replace-mode resources land here too so a delete (step 2) is
-// followed by a fresh apply.
+// Replace-mode is two kubectl invocations -- a delete followed by
+// a re-creating apply -- but conceptually one operation, so its
+// progress line ("yconverge converge-mode=replace") covers both.
+// applyGroups encodes that structure: each group is one mode and
+// holds the one or two kubectl invocations behind it; the runner
+// emits the group's header at most once and only when at least
+// one invocation produces non-suppressed output.
 //
-// Each step tolerates the empty-match stderr ("no objects passed
-// to <verb>") so re-running yconverge against a kustomization
-// that uses only one mode doesn't print four "error" lines.
-// Step 1 also tolerates "AlreadyExists" so create-mode is the
-// "skip if exists" semantic the bash plugin documents.
+// Each step's tolerance lists keep idempotent paths quiet:
+// empty-selector match ("no objects passed to <verb>") on apply,
+// AlreadyExists on create re-runs, and "No resources found" on
+// the delete step's stdout when nothing is replace-labelled.
 //
-// Dry-run forwards to delete + create + apply so a replace-mode
-// resource's dry-run plan is provably non-mutating.
+// Dry-run forwards to every invocation including delete, so a
+// replace-mode resource's dry-run plan is provably non-mutating
+// end-to-end.
 func kubectlApply(ctx context.Context, opts Options) error {
-	for _, step := range applySteps(opts) {
-		if err := runKubectlTolerant(ctx, step.stderrTolerate, step.stdoutSuppress, step.args...); err != nil {
-			return err
+	out := opts.progressOut()
+	for _, g := range applyGroups(opts) {
+		var groupBuf bytes.Buffer
+		for _, step := range g.invocations {
+			if err := runApplyInvocation(ctx, step, &groupBuf); err != nil {
+				// On failure, surface anything the group produced
+				// so far so the diagnostic isn't preceded by an
+				// orphaned header. Then propagate the error.
+				if groupBuf.Len() > 0 {
+					if g.mode != "" {
+						fmt.Fprintf(out, "yconverge converge-mode=%s\n", g.mode)
+					}
+					_, _ = out.Write(groupBuf.Bytes())
+				}
+				return err
+			}
+		}
+		if groupBuf.Len() > 0 {
+			if g.mode != "" {
+				fmt.Fprintf(out, "yconverge converge-mode=%s\n", g.mode)
+			}
+			_, _ = out.Write(groupBuf.Bytes())
 		}
 	}
 	return nil
 }
 
-// applyStep is the data shape behind one of the five label-routed
-// kubectl invocations. Pulled out so unit tests can assert the
-// argv each step produces without spawning kubectl.
+// applyStep is one kubectl invocation. Pulled out so tests can
+// assert the argv without spawning kubectl.
 type applyStep struct {
 	args           []string
 	stderrTolerate []string
 	stdoutSuppress []string
 }
 
-// applySteps returns the five-step apply plan for the given
-// Options. The returned slice's order matters and is preserved by
-// the runtime: create -> delete (replace) -> serverside-force ->
-// serverside -> plain-apply (the rest, including replace-mode
-// resources reapplied after their delete).
-func applySteps(opts Options) []applyStep {
+// applyGroup gathers one or more applySteps under a single mode
+// header. The runner emits the header once before the first
+// non-empty invocation's output. mode == "" means no header
+// (the unlabelled / default bucket -- kubectl's per-resource
+// lines speak for themselves).
+type applyGroup struct {
+	mode        string
+	invocations []applyStep
+}
+
+// applyGroups returns the label-routed apply plan for opts.
+// Group order matters and is preserved by the runtime: create
+// -> replace -> serverside-force -> serverside -> default.
+//
+// Replace-mode is the only group with two invocations: the delete
+// followed by an apply that re-creates the same selector's
+// resources. Both go under one "yconverge converge-mode=replace"
+// header to match the user-facing semantics ("replace" is one
+// operation conceptually).
+//
+// The default group's selector excludes every other mode so the
+// replace-mode resources don't get re-applied a second time
+// here.
+func applyGroups(opts Options) []applyGroup {
 	dryRun := ""
 	if opts.DryRun == "server" {
 		dryRun = "--dry-run=server"
@@ -173,45 +221,75 @@ func applySteps(opts Options) []applyStep {
 		return append(out, dirFlag...)
 	}
 
-	return []applyStep{
-		// 1. create: --save-config; skip-if-exists via AlreadyExists tolerance.
+	return []applyGroup{
 		{
-			args:           withDryRun(ctxFlag, "create", "--save-config", sel("create")),
-			stderrTolerate: []string{"AlreadyExists", "no objects passed to create"},
+			mode: "create",
+			invocations: []applyStep{
+				{
+					args:           withDryRun(ctxFlag, "create", "--save-config", sel("create")),
+					stderrTolerate: []string{"AlreadyExists", "no objects passed to create"},
+				},
+			},
 		},
-		// 2. delete (replace-mode resources). kubectl prints "No
-		// resources found" to STDOUT (not stderr) with exit 0 when
-		// the selector matches nothing, so we suppress that line on
-		// stdout rather than tolerating it on stderr. Real deletes
-		// ("configmap "x" deleted") still pass through.
-		// kubectl simulates under --dry-run=server so the plan
-		// stays non-mutating end-to-end.
 		{
-			args:           withDryRun(ctxFlag, "delete", sel("replace")),
-			stdoutSuppress: []string{"No resources found"},
+			// Delete + re-apply for replace-mode resources, both
+			// under one "converge-mode=replace" header. The delete
+			// step prints "No resources found" to STDOUT (not stderr)
+			// with exit 0 when nothing matches, so we suppress that
+			// stdout line; real deletes ("<kind> 'x' deleted") still
+			// pass through.
+			mode: "replace",
+			invocations: []applyStep{
+				{
+					args:           withDryRun(ctxFlag, "delete", sel("replace")),
+					stdoutSuppress: []string{"No resources found"},
+				},
+				{
+					args:           withDryRun(ctxFlag, "apply", sel("replace")),
+					stderrTolerate: []string{"no objects passed to apply"},
+				},
+			},
 		},
-		// 3. apply --server-side --force-conflicts.
 		{
-			args: withDryRun(ctxFlag, "apply",
-				"--server-side", "--force-conflicts", "--field-manager=y-cluster",
-				sel("serverside-force")),
-			stderrTolerate: []string{"no objects passed to apply"},
+			mode: "serverside-force",
+			invocations: []applyStep{
+				{
+					args: withDryRun(ctxFlag, "apply",
+						"--server-side", "--force-conflicts", "--field-manager=y-cluster",
+						sel("serverside-force")),
+					stderrTolerate: []string{"no objects passed to apply"},
+				},
+			},
 		},
-		// 4. apply --server-side (no force).
 		{
-			args: withDryRun(ctxFlag, "apply",
-				"--server-side", "--field-manager=y-cluster",
-				sel("serverside")),
-			stderrTolerate: []string{"no objects passed to apply"},
+			mode: "serverside",
+			invocations: []applyStep{
+				{
+					args: withDryRun(ctxFlag, "apply",
+						"--server-side", "--field-manager=y-cluster",
+						sel("serverside")),
+					stderrTolerate: []string{"no objects passed to apply"},
+				},
+			},
 		},
-		// 5. plain apply for everything else (including replace-mode
-		// resources, now reapplied after the delete in step 2).
 		{
-			args: withDryRun(ctxFlag, "apply",
-				"--selector="+ConvergeModeLabel+"!=create,"+
-					ConvergeModeLabel+"!=serverside,"+
-					ConvergeModeLabel+"!=serverside-force"),
-			stderrTolerate: []string{"no objects passed to apply"},
+			// Default bucket: unlabelled resources only. Replace-mode
+			// resources are NOT re-applied here -- they were already
+			// re-created in the replace group's second invocation
+			// above, so the negative selector excludes replace too.
+			// No header: kubectl's `<kind>/<name> created` lines are
+			// enough signal.
+			mode: "",
+			invocations: []applyStep{
+				{
+					args: withDryRun(ctxFlag, "apply",
+						"--selector="+ConvergeModeLabel+"!=create,"+
+							ConvergeModeLabel+"!=replace,"+
+							ConvergeModeLabel+"!=serverside,"+
+							ConvergeModeLabel+"!=serverside-force"),
+					stderrTolerate: []string{"no objects passed to apply"},
+				},
+			},
 		},
 	}
 }
@@ -224,7 +302,7 @@ func applySteps(opts Options) []applyStep {
 // Empty namespace omits `-n`, matching kubectl wait's "use the
 // context's default namespace" behaviour. Cluster-scoped kinds
 // pass empty here.
-func kubectlWait(ctx context.Context, contextName, resource, namespace, forSpec string, timeout time.Duration) error {
+func kubectlWait(ctx context.Context, progress io.Writer, contextName, resource, namespace, forSpec string, timeout time.Duration) error {
 	args := []string{
 		"--context=" + contextName,
 		"wait", resource,
@@ -234,13 +312,13 @@ func kubectlWait(ctx context.Context, contextName, resource, namespace, forSpec 
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
-	return runKubectlStreaming(ctx, args...)
+	return runKubectlStreaming(ctx, progress, args...)
 }
 
 // kubectlRolloutStatus runs `kubectl --context=<...> rollout
 // status <resource> -n <ns> --timeout=<timeout>`. resource is
 // already in the `<kind>/<name>` form the bash plugin used.
-func kubectlRolloutStatus(ctx context.Context, contextName, resource, namespace string, timeout time.Duration) error {
+func kubectlRolloutStatus(ctx context.Context, progress io.Writer, contextName, resource, namespace string, timeout time.Duration) error {
 	args := []string{
 		"--context=" + contextName,
 		"rollout", "status", resource,
@@ -249,5 +327,5 @@ func kubectlRolloutStatus(ctx context.Context, contextName, resource, namespace 
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
-	return runKubectlStreaming(ctx, args...)
+	return runKubectlStreaming(ctx, progress, args...)
 }

--- a/pkg/yconverge/kubectl.go
+++ b/pkg/yconverge/kubectl.go
@@ -34,29 +34,52 @@ func runKubectlStreaming(ctx context.Context, args ...string) error {
 	return nil
 }
 
-// runKubectlTolerant runs `kubectl <args...>` like
-// runKubectlStreaming but suppresses the entire invocation when
-// kubectl's stderr matches any of the `tolerate` substrings. Used
-// for the converge-mode steps where "no objects passed to <verb>"
-// (an empty selector match) and "AlreadyExists" (re-run of a
-// create-mode resource) are the expected idempotent path.
+// runKubectlTolerant runs `kubectl <args...>` and suppresses
+// "expected idempotent" output. Two slots:
 //
-// stdout still streams to the user's terminal so the kubectl-style
-// per-resource lines are visible. stderr is captured: if the error
-// is tolerated, we say nothing; if not, we forward the captured
-// stderr to the user before returning so the diagnostic isn't
-// swallowed.
-func runKubectlTolerant(ctx context.Context, tolerate []string, args ...string) error {
+//   - stderrTolerate: if kubectl exits non-zero AND its stderr
+//     matches one of these substrings, treat as success and
+//     drop the stderr text. Used for "no objects passed to
+//     <verb>" (empty selector match) and "AlreadyExists" (re-run
+//     of a create-mode resource).
+//   - stdoutSuppress: if kubectl's stdout matches one of these
+//     substrings, drop the stdout text from the user's view.
+//     Used for `kubectl delete`'s "No resources found" line --
+//     it lands on stdout with exit 0, so without suppression a
+//     vanilla yconverge run prints noise even when there's
+//     nothing for the delete step to do.
+//
+// Both lists default to nil. stdout that doesn't match a
+// suppress pattern is forwarded verbatim so the kubectl-style
+// per-resource lines (`<kind>/<name> serverside-applied` etc.)
+// reach the user. stderr that doesn't match a tolerate pattern
+// is forwarded too, before the error propagates, so a real
+// kubectl diagnostic isn't swallowed.
+func runKubectlTolerant(ctx context.Context, stderrTolerate, stdoutSuppress []string, args ...string) error {
 	cmd := exec.CommandContext(ctx, "kubectl", args...)
-	var stderr bytes.Buffer
-	cmd.Stdout = os.Stdout
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
+
+	if sout := stdout.String(); sout != "" {
+		suppress := false
+		for _, p := range stdoutSuppress {
+			if strings.Contains(sout, p) {
+				suppress = true
+				break
+			}
+		}
+		if !suppress {
+			_, _ = os.Stdout.WriteString(sout)
+		}
+	}
+
 	if err == nil {
 		return nil
 	}
 	msg := stderr.String()
-	for _, t := range tolerate {
+	for _, t := range stderrTolerate {
 		if strings.Contains(msg, t) {
 			return nil
 		}
@@ -112,7 +135,7 @@ func argSummary(args []string) string {
 // resource's dry-run plan is provably non-mutating.
 func kubectlApply(ctx context.Context, opts Options) error {
 	for _, step := range applySteps(opts) {
-		if err := runKubectlTolerant(ctx, step.tolerate, step.args...); err != nil {
+		if err := runKubectlTolerant(ctx, step.stderrTolerate, step.stdoutSuppress, step.args...); err != nil {
 			return err
 		}
 	}
@@ -123,8 +146,9 @@ func kubectlApply(ctx context.Context, opts Options) error {
 // kubectl invocations. Pulled out so unit tests can assert the
 // argv each step produces without spawning kubectl.
 type applyStep struct {
-	args     []string
-	tolerate []string
+	args           []string
+	stderrTolerate []string
+	stdoutSuppress []string
 }
 
 // applySteps returns the five-step apply plan for the given
@@ -152,28 +176,33 @@ func applySteps(opts Options) []applyStep {
 	return []applyStep{
 		// 1. create: --save-config; skip-if-exists via AlreadyExists tolerance.
 		{
-			args:     withDryRun(ctxFlag, "create", "--save-config", sel("create")),
-			tolerate: []string{"AlreadyExists", "no objects passed to create"},
+			args:           withDryRun(ctxFlag, "create", "--save-config", sel("create")),
+			stderrTolerate: []string{"AlreadyExists", "no objects passed to create"},
 		},
-		// 2. delete (replace-mode resources). kubectl simulates under
-		// --dry-run=server so the plan stays non-mutating end-to-end.
+		// 2. delete (replace-mode resources). kubectl prints "No
+		// resources found" to STDOUT (not stderr) with exit 0 when
+		// the selector matches nothing, so we suppress that line on
+		// stdout rather than tolerating it on stderr. Real deletes
+		// ("configmap "x" deleted") still pass through.
+		// kubectl simulates under --dry-run=server so the plan
+		// stays non-mutating end-to-end.
 		{
-			args:     withDryRun(ctxFlag, "delete", sel("replace")),
-			tolerate: []string{"No resources found"},
+			args:           withDryRun(ctxFlag, "delete", sel("replace")),
+			stdoutSuppress: []string{"No resources found"},
 		},
 		// 3. apply --server-side --force-conflicts.
 		{
 			args: withDryRun(ctxFlag, "apply",
 				"--server-side", "--force-conflicts", "--field-manager=y-cluster",
 				sel("serverside-force")),
-			tolerate: []string{"no objects passed to apply"},
+			stderrTolerate: []string{"no objects passed to apply"},
 		},
 		// 4. apply --server-side (no force).
 		{
 			args: withDryRun(ctxFlag, "apply",
 				"--server-side", "--field-manager=y-cluster",
 				sel("serverside")),
-			tolerate: []string{"no objects passed to apply"},
+			stderrTolerate: []string{"no objects passed to apply"},
 		},
 		// 5. plain apply for everything else (including replace-mode
 		// resources, now reapplied after the delete in step 2).
@@ -182,7 +211,7 @@ func applySteps(opts Options) []applyStep {
 				"--selector="+ConvergeModeLabel+"!=create,"+
 					ConvergeModeLabel+"!=serverside,"+
 					ConvergeModeLabel+"!=serverside-force"),
-			tolerate: []string{"no objects passed to apply"},
+			stderrTolerate: []string{"no objects passed to apply"},
 		},
 	}
 }

--- a/pkg/yconverge/kubectl.go
+++ b/pkg/yconverge/kubectl.go
@@ -111,82 +111,80 @@ func argSummary(args []string) string {
 // Dry-run forwards to delete + create + apply so a replace-mode
 // resource's dry-run plan is provably non-mutating.
 func kubectlApply(ctx context.Context, opts Options) error {
+	for _, step := range applySteps(opts) {
+		if err := runKubectlTolerant(ctx, step.tolerate, step.args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyStep is the data shape behind one of the five label-routed
+// kubectl invocations. Pulled out so unit tests can assert the
+// argv each step produces without spawning kubectl.
+type applyStep struct {
+	args     []string
+	tolerate []string
+}
+
+// applySteps returns the five-step apply plan for the given
+// Options. The returned slice's order matters and is preserved by
+// the runtime: create -> delete (replace) -> serverside-force ->
+// serverside -> plain-apply (the rest, including replace-mode
+// resources reapplied after their delete).
+func applySteps(opts Options) []applyStep {
 	dryRun := ""
 	if opts.DryRun == "server" {
 		dryRun = "--dry-run=server"
 	}
 	ctxFlag := "--context=" + opts.Context
 	dirFlag := []string{"-k", opts.KustomizeDir}
+	sel := func(eq string) string { return "--selector=" + ConvergeModeLabel + "=" + eq }
 
-	// 1. create: --save-config; skip-if-exists via AlreadyExists tolerance.
-	createArgs := []string{ctxFlag, "create", "--save-config",
-		"--selector=" + ConvergeModeLabel + "=create"}
-	if dryRun != "" {
-		createArgs = append(createArgs, dryRun)
-	}
-	createArgs = append(createArgs, dirFlag...)
-	if err := runKubectlTolerant(ctx,
-		[]string{"AlreadyExists", "no objects passed to create"},
-		createArgs...,
-	); err != nil {
-		return err
-	}
-
-	// 2. delete (replace-mode resources). kubectl simulates under
-	// --dry-run=server so the plan stays non-mutating end-to-end.
-	deleteArgs := []string{ctxFlag, "delete",
-		"--selector=" + ConvergeModeLabel + "=replace"}
-	if dryRun != "" {
-		deleteArgs = append(deleteArgs, dryRun)
-	}
-	deleteArgs = append(deleteArgs, dirFlag...)
-	if err := runKubectlTolerant(ctx,
-		[]string{"No resources found"},
-		deleteArgs...,
-	); err != nil {
-		return err
-	}
-
-	// 3. apply --server-side --force-conflicts.
-	for _, mode := range []struct {
-		label string
-		flags []string
-	}{
-		{"serverside-force", []string{"--server-side", "--force-conflicts", "--field-manager=y-cluster"}},
-		{"serverside", []string{"--server-side", "--field-manager=y-cluster"}},
-	} {
-		args := []string{ctxFlag, "apply"}
-		args = append(args, mode.flags...)
-		args = append(args, "--selector="+ConvergeModeLabel+"="+mode.label)
+	withDryRun := func(args ...string) []string {
+		out := append([]string(nil), args...)
 		if dryRun != "" {
-			args = append(args, dryRun)
+			out = append(out, dryRun)
 		}
-		args = append(args, dirFlag...)
-		if err := runKubectlTolerant(ctx,
-			[]string{"no objects passed to apply"},
-			args...,
-		); err != nil {
-			return err
-		}
+		return append(out, dirFlag...)
 	}
 
-	// 5. plain apply for everything else (including replace-mode
-	// resources, now reapplied after the delete in step 2).
-	noneArgs := []string{ctxFlag, "apply",
-		"--selector=" + ConvergeModeLabel + "!=create," +
-			ConvergeModeLabel + "!=serverside," +
-			ConvergeModeLabel + "!=serverside-force"}
-	if dryRun != "" {
-		noneArgs = append(noneArgs, dryRun)
+	return []applyStep{
+		// 1. create: --save-config; skip-if-exists via AlreadyExists tolerance.
+		{
+			args:     withDryRun(ctxFlag, "create", "--save-config", sel("create")),
+			tolerate: []string{"AlreadyExists", "no objects passed to create"},
+		},
+		// 2. delete (replace-mode resources). kubectl simulates under
+		// --dry-run=server so the plan stays non-mutating end-to-end.
+		{
+			args:     withDryRun(ctxFlag, "delete", sel("replace")),
+			tolerate: []string{"No resources found"},
+		},
+		// 3. apply --server-side --force-conflicts.
+		{
+			args: withDryRun(ctxFlag, "apply",
+				"--server-side", "--force-conflicts", "--field-manager=y-cluster",
+				sel("serverside-force")),
+			tolerate: []string{"no objects passed to apply"},
+		},
+		// 4. apply --server-side (no force).
+		{
+			args: withDryRun(ctxFlag, "apply",
+				"--server-side", "--field-manager=y-cluster",
+				sel("serverside")),
+			tolerate: []string{"no objects passed to apply"},
+		},
+		// 5. plain apply for everything else (including replace-mode
+		// resources, now reapplied after the delete in step 2).
+		{
+			args: withDryRun(ctxFlag, "apply",
+				"--selector="+ConvergeModeLabel+"!=create,"+
+					ConvergeModeLabel+"!=serverside,"+
+					ConvergeModeLabel+"!=serverside-force"),
+			tolerate: []string{"no objects passed to apply"},
+		},
 	}
-	noneArgs = append(noneArgs, dirFlag...)
-	if err := runKubectlTolerant(ctx,
-		[]string{"no objects passed to apply"},
-		noneArgs...,
-	); err != nil {
-		return err
-	}
-	return nil
 }
 
 // kubectlWait runs `kubectl --context=<...> wait <resource> -n <ns>

--- a/pkg/yconverge/kubectl.go
+++ b/pkg/yconverge/kubectl.go
@@ -1,31 +1,29 @@
 package yconverge
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
-// runKubectl executes `kubectl <args...>` with stdout / stderr
-// forwarded to the host process so the user sees verbatim what
-// kubectl says -- the line shapes (`<kind>/<name> serverside-applied`,
-// `deployment.apps/foo condition met`, etc.) developers already
-// know from running kubectl directly.
-//
-// Output is intentionally NOT captured: the callers don't post-
-// process it (in contrast to e.g. cluster.RunCtr where we forward
-// a stream into the user's pipe). Forward-without-capture keeps
-// the wrapper invisible -- a `kubectl yconverge` invocation looks
-// the same as the underlying kubectl invocation modulo the
-// `kubectl` prefix.
-//
-// Errors carry the exit code and the args so a failure surfaces
-// "kubectl apply -k /tmp/xyz: exit status 1" -- enough for a
-// scripted caller to act, while the actual diagnostic text is
-// already on the user's terminal from kubectl's stderr.
-func runKubectl(ctx context.Context, args ...string) error {
+// ConvergeModeLabel is the resource label kustomizations stamp on
+// resources to opt into a non-default apply strategy. Mirrors the
+// label introduced by the bash kubectl-yconverge plugin so existing
+// `commonLabels: { yolean.se/converge-mode: serverside-force }`
+// declarations keep working under the Go binary.
+const ConvergeModeLabel = "yolean.se/converge-mode"
+
+// runKubectlStreaming executes `kubectl <args...>` with stdin /
+// stdout / stderr forwarded to the host process. Output is not
+// captured -- the user sees verbatim what kubectl says, which is
+// the line shape (`<kind>/<name> serverside-applied`,
+// `... condition met`) developers already know from running
+// kubectl directly.
+func runKubectlStreaming(ctx context.Context, args ...string) error {
 	cmd := exec.CommandContext(ctx, "kubectl", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -34,6 +32,37 @@ func runKubectl(ctx context.Context, args ...string) error {
 		return fmt.Errorf("kubectl %s: %w", argSummary(args), err)
 	}
 	return nil
+}
+
+// runKubectlTolerant runs `kubectl <args...>` like
+// runKubectlStreaming but suppresses the entire invocation when
+// kubectl's stderr matches any of the `tolerate` substrings. Used
+// for the converge-mode steps where "no objects passed to <verb>"
+// (an empty selector match) and "AlreadyExists" (re-run of a
+// create-mode resource) are the expected idempotent path.
+//
+// stdout still streams to the user's terminal so the kubectl-style
+// per-resource lines are visible. stderr is captured: if the error
+// is tolerated, we say nothing; if not, we forward the captured
+// stderr to the user before returning so the diagnostic isn't
+// swallowed.
+func runKubectlTolerant(ctx context.Context, tolerate []string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	var stderr bytes.Buffer
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+	msg := stderr.String()
+	for _, t := range tolerate {
+		if strings.Contains(msg, t) {
+			return nil
+		}
+	}
+	_, _ = os.Stderr.Write([]byte(msg))
+	return fmt.Errorf("kubectl %s: %w", argSummary(args), err)
 }
 
 // argSummary returns a short description of an argv for error
@@ -59,28 +88,105 @@ func argSummary(args []string) string {
 	return out
 }
 
-// kubectlApply runs `kubectl --context=<...> apply --server-side
-// --force-conflicts --field-manager=y-cluster -k <dir>` against
-// the configured context. The flag set matches what
-// pkg/k8sapply.Apply does internally so the wire-level effect is
-// identical -- only the developer-visible output differs.
+// kubectlApply renders the kustomize tree at opts.KustomizeDir and
+// applies its resources via five label-routed kubectl invocations,
+// matching the bash kubectl-yconverge plugin (90e8923) one-for-one:
 //
-// --dry-run=server forwards through; the bash plugin's
-// "client mode is rejected" rule is preserved because kubectl
-// itself rejects --dry-run=client with --server-side.
+//  1. yolean.se/converge-mode=create       -> kubectl create --save-config
+//  2. yolean.se/converge-mode=replace      -> kubectl delete (followed by step 5's apply)
+//  3. yolean.se/converge-mode=serverside-force -> kubectl apply --server-side --force-conflicts
+//  4. yolean.se/converge-mode=serverside   -> kubectl apply --server-side
+//  5. (no label, or label=replace)         -> kubectl apply
+//
+// Step 5's selector excludes the labels handled in 1, 3, 4 -- the
+// replace-mode resources land here too so a delete (step 2) is
+// followed by a fresh apply.
+//
+// Each step tolerates the empty-match stderr ("no objects passed
+// to <verb>") so re-running yconverge against a kustomization
+// that uses only one mode doesn't print four "error" lines.
+// Step 1 also tolerates "AlreadyExists" so create-mode is the
+// "skip if exists" semantic the bash plugin documents.
+//
+// Dry-run forwards to delete + create + apply so a replace-mode
+// resource's dry-run plan is provably non-mutating.
 func kubectlApply(ctx context.Context, opts Options) error {
-	args := []string{
-		"--context=" + opts.Context,
-		"apply",
-		"--server-side",
-		"--force-conflicts",
-		"--field-manager=y-cluster",
-		"-k", opts.KustomizeDir,
-	}
+	dryRun := ""
 	if opts.DryRun == "server" {
-		args = append(args, "--dry-run=server")
+		dryRun = "--dry-run=server"
 	}
-	return runKubectl(ctx, args...)
+	ctxFlag := "--context=" + opts.Context
+	dirFlag := []string{"-k", opts.KustomizeDir}
+
+	// 1. create: --save-config; skip-if-exists via AlreadyExists tolerance.
+	createArgs := []string{ctxFlag, "create", "--save-config",
+		"--selector=" + ConvergeModeLabel + "=create"}
+	if dryRun != "" {
+		createArgs = append(createArgs, dryRun)
+	}
+	createArgs = append(createArgs, dirFlag...)
+	if err := runKubectlTolerant(ctx,
+		[]string{"AlreadyExists", "no objects passed to create"},
+		createArgs...,
+	); err != nil {
+		return err
+	}
+
+	// 2. delete (replace-mode resources). kubectl simulates under
+	// --dry-run=server so the plan stays non-mutating end-to-end.
+	deleteArgs := []string{ctxFlag, "delete",
+		"--selector=" + ConvergeModeLabel + "=replace"}
+	if dryRun != "" {
+		deleteArgs = append(deleteArgs, dryRun)
+	}
+	deleteArgs = append(deleteArgs, dirFlag...)
+	if err := runKubectlTolerant(ctx,
+		[]string{"No resources found"},
+		deleteArgs...,
+	); err != nil {
+		return err
+	}
+
+	// 3. apply --server-side --force-conflicts.
+	for _, mode := range []struct {
+		label string
+		flags []string
+	}{
+		{"serverside-force", []string{"--server-side", "--force-conflicts", "--field-manager=y-cluster"}},
+		{"serverside", []string{"--server-side", "--field-manager=y-cluster"}},
+	} {
+		args := []string{ctxFlag, "apply"}
+		args = append(args, mode.flags...)
+		args = append(args, "--selector="+ConvergeModeLabel+"="+mode.label)
+		if dryRun != "" {
+			args = append(args, dryRun)
+		}
+		args = append(args, dirFlag...)
+		if err := runKubectlTolerant(ctx,
+			[]string{"no objects passed to apply"},
+			args...,
+		); err != nil {
+			return err
+		}
+	}
+
+	// 5. plain apply for everything else (including replace-mode
+	// resources, now reapplied after the delete in step 2).
+	noneArgs := []string{ctxFlag, "apply",
+		"--selector=" + ConvergeModeLabel + "!=create," +
+			ConvergeModeLabel + "!=serverside," +
+			ConvergeModeLabel + "!=serverside-force"}
+	if dryRun != "" {
+		noneArgs = append(noneArgs, dryRun)
+	}
+	noneArgs = append(noneArgs, dirFlag...)
+	if err := runKubectlTolerant(ctx,
+		[]string{"no objects passed to apply"},
+		noneArgs...,
+	); err != nil {
+		return err
+	}
+	return nil
 }
 
 // kubectlWait runs `kubectl --context=<...> wait <resource> -n <ns>
@@ -101,7 +207,7 @@ func kubectlWait(ctx context.Context, contextName, resource, namespace, forSpec 
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
-	return runKubectl(ctx, args...)
+	return runKubectlStreaming(ctx, args...)
 }
 
 // kubectlRolloutStatus runs `kubectl --context=<...> rollout
@@ -116,5 +222,5 @@ func kubectlRolloutStatus(ctx context.Context, contextName, resource, namespace 
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
-	return runKubectl(ctx, args...)
+	return runKubectlStreaming(ctx, args...)
 }

--- a/pkg/yconverge/kubectl_test.go
+++ b/pkg/yconverge/kubectl_test.go
@@ -6,148 +6,194 @@ import (
 	"testing"
 )
 
-// TestApplySteps_OrderAndCount: the bash plugin runs five
-// label-routed kubectl invocations in a fixed order. Pin the
-// order here so a refactor that reshuffles them (or drops the
-// fall-through plain-apply step) fails loudly.
-func TestApplySteps_OrderAndCount(t *testing.T) {
-	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k"})
-	if len(steps) != 5 {
-		t.Fatalf("want 5 steps, got %d", len(steps))
+// TestApplyGroups_OrderAndCount: the apply plan is five groups in
+// a fixed order. Pin both the count and the mode-header sequence
+// so a refactor that reshuffles them (or drops the unlabelled
+// fall-through group) fails loudly.
+func TestApplyGroups_OrderAndCount(t *testing.T) {
+	groups := applyGroups(Options{Context: "local", KustomizeDir: "/tmp/k"})
+	if len(groups) != 5 {
+		t.Fatalf("want 5 groups, got %d", len(groups))
 	}
 
-	// Step ordering, asserted on the first verb-ish token after
-	// --context=... so the test stays stable if a flag's order
-	// inside one step shifts.
-	wantVerbs := []string{"create", "delete", "apply", "apply", "apply"}
-	for i, want := range wantVerbs {
-		if got := steps[i].args[1]; got != want {
-			t.Errorf("step %d: verb %q, want %q (full args: %v)", i, got, want, steps[i].args)
+	wantModes := []string{"create", "replace", "serverside-force", "serverside", ""}
+	for i, want := range wantModes {
+		if got := groups[i].mode; got != want {
+			t.Errorf("group %d: mode %q, want %q", i, got, want)
 		}
 	}
 }
 
-// TestApplySteps_PerStepArgs locks the exact argv each step
-// produces for a vanilla (non-dry-run) Options. This is the
-// regression guard for the converge-mode contract: any drift
-// in `--save-config`, `--server-side`, `--force-conflicts`,
-// `--field-manager=y-cluster`, or the selector formula
-// surfaces as a test failure rather than as silent semantic
-// change against the cluster.
-func TestApplySteps_PerStepArgs(t *testing.T) {
-	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k"})
-	want := [][]string{
-		{
-			"--context=local", "create", "--save-config",
-			"--selector=yolean.se/converge-mode=create",
-			"-k", "/tmp/k",
-		},
-		{
-			"--context=local", "delete",
-			"--selector=yolean.se/converge-mode=replace",
-			"-k", "/tmp/k",
-		},
-		{
-			"--context=local", "apply",
-			"--server-side", "--force-conflicts", "--field-manager=y-cluster",
-			"--selector=yolean.se/converge-mode=serverside-force",
-			"-k", "/tmp/k",
-		},
-		{
-			"--context=local", "apply",
-			"--server-side", "--field-manager=y-cluster",
-			"--selector=yolean.se/converge-mode=serverside",
-			"-k", "/tmp/k",
-		},
-		{
-			"--context=local", "apply",
-			"--selector=yolean.se/converge-mode!=create," +
-				"yolean.se/converge-mode!=serverside," +
-				"yolean.se/converge-mode!=serverside-force",
-			"-k", "/tmp/k",
-		},
-	}
-	for i, w := range want {
-		if !reflect.DeepEqual(steps[i].args, w) {
-			t.Errorf("step %d args mismatch\n got:  %v\n want: %v", i, steps[i].args, w)
+// TestApplyGroups_ReplaceHasTwoInvocations is the structural
+// invariant for the replace mode: one delete followed by one
+// re-creating apply, both under one progress header. If a future
+// refactor splits or merges them, the user-facing line ("yconverge
+// converge-mode=replace" covering both delete + recreate) breaks.
+func TestApplyGroups_ReplaceHasTwoInvocations(t *testing.T) {
+	groups := applyGroups(Options{Context: "local", KustomizeDir: "/tmp/k"})
+
+	for i, g := range groups {
+		want := 1
+		if g.mode == "replace" {
+			want = 2
+		}
+		if len(g.invocations) != want {
+			t.Errorf("group %d (mode=%q): %d invocations, want %d",
+				i, g.mode, len(g.invocations), want)
 		}
 	}
-}
 
-// TestApplySteps_DryRunForwards: --dry-run=server must reach
-// every step (delete + create + apply variants), so a dry-run of
-// a kustomization with replace-mode resources is provably
-// non-mutating end-to-end -- the bash plugin's behaviour.
-func TestApplySteps_DryRunForwards(t *testing.T) {
-	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k", DryRun: "server"})
-	for i, s := range steps {
+	// Replace's two invocations are delete then apply with the
+	// same selector -- catches an accidental selector drift
+	// between them.
+	replace := groups[1]
+	if got := replace.invocations[0].args[1]; got != "delete" {
+		t.Errorf("replace invocation 0: verb %q, want delete", got)
+	}
+	if got := replace.invocations[1].args[1]; got != "apply" {
+		t.Errorf("replace invocation 1: verb %q, want apply", got)
+	}
+	sel := "--selector=" + ConvergeModeLabel + "=replace"
+	for j, inv := range replace.invocations {
 		found := false
-		for _, a := range s.args {
-			if a == "--dry-run=server" {
+		for _, a := range inv.args {
+			if a == sel {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("step %d (verb=%s) missing --dry-run=server: %v", i, s.args[1], s.args)
+			t.Errorf("replace invocation %d missing %q: %v", j, sel, inv.args)
 		}
 	}
 }
 
-// TestApplySteps_NoDryRunByDefault confirms the inverse: an
-// empty Options.DryRun must not insert --dry-run=anything.
-// Catches a typo where a default value (e.g. "none") gets
-// forwarded as a flag.
-func TestApplySteps_NoDryRunByDefault(t *testing.T) {
-	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k"})
-	for i, s := range steps {
-		for _, a := range s.args {
-			if strings.HasPrefix(a, "--dry-run=") {
-				t.Errorf("step %d unexpectedly carries %q: %v", i, a, s.args)
+// TestApplyGroups_DefaultExcludesReplaceToo: the unlabelled bucket's
+// negative selector must exclude replace too, because replace's
+// resources are re-applied inside the replace group's second
+// invocation. If the default group also re-applied them we'd
+// double-apply -- visible as duplicate "<kind>/<name> created"
+// lines on first run.
+func TestApplyGroups_DefaultExcludesReplaceToo(t *testing.T) {
+	groups := applyGroups(Options{Context: "local", KustomizeDir: "/tmp/k"})
+	def := groups[4]
+	if def.mode != "" {
+		t.Fatalf("group 4 should be the default (mode=\"\") group, got mode=%q", def.mode)
+	}
+	args := def.invocations[0].args
+	var sel string
+	for _, a := range args {
+		if strings.HasPrefix(a, "--selector=") {
+			sel = a
+			break
+		}
+	}
+	for _, mode := range []string{"create", "replace", "serverside", "serverside-force"} {
+		want := ConvergeModeLabel + "!=" + mode
+		if !strings.Contains(sel, want) {
+			t.Errorf("default selector missing %q\nsel: %s", want, sel)
+		}
+	}
+}
+
+// TestApplyGroups_DryRunForwards: --dry-run=server must reach
+// every invocation, including delete and replace's recreate, so
+// a dry-run of a replace-mode resource is provably non-mutating
+// end-to-end.
+func TestApplyGroups_DryRunForwards(t *testing.T) {
+	groups := applyGroups(Options{Context: "local", KustomizeDir: "/tmp/k", DryRun: "server"})
+	for gi, g := range groups {
+		for ii, inv := range g.invocations {
+			found := false
+			for _, a := range inv.args {
+				if a == "--dry-run=server" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("group %d (mode=%q) invocation %d missing --dry-run=server: %v",
+					gi, g.mode, ii, inv.args)
 			}
 		}
 	}
 }
 
-// TestApplySteps_TolerateContract pins the per-step "expected
-// empty / idempotent" output substrings, split between the two
-// channels kubectl uses:
+// TestApplyGroups_NoDryRunByDefault confirms the inverse: an
+// empty Options.DryRun must not insert --dry-run=anything. Catches
+// a typo where a default value (e.g. "none") gets forwarded.
+func TestApplyGroups_NoDryRunByDefault(t *testing.T) {
+	groups := applyGroups(Options{Context: "local", KustomizeDir: "/tmp/k"})
+	for gi, g := range groups {
+		for ii, inv := range g.invocations {
+			for _, a := range inv.args {
+				if strings.HasPrefix(a, "--dry-run=") {
+					t.Errorf("group %d (mode=%q) invocation %d unexpectedly carries %q",
+						gi, g.mode, ii, a)
+				}
+			}
+		}
+	}
+}
+
+// TestApplyGroups_TolerateContract pins the per-invocation
+// "expected idempotent" output substrings, split between the
+// two channels kubectl uses:
 //
 //   - stderrTolerate: stderr substrings that, together with a
-//     non-zero exit, count as success. Used for the apply / create
-//     "no objects passed to <verb>" empty-selector case and for
-//     create's AlreadyExists re-run case.
-//   - stdoutSuppress: stdout substrings that, when produced by an
-//     otherwise successful kubectl run, are dropped before
-//     forwarding to the user. Used for `kubectl delete`'s
-//     "No resources found" line on empty match (delete prints
-//     this to stdout, not stderr, with exit 0).
+//     non-zero exit, count as success ("no objects passed to
+//     <verb>" empty-selector case, "AlreadyExists" on create
+//     re-runs).
+//   - stdoutSuppress: stdout substrings that, on otherwise
+//     successful runs, are dropped before forwarding (kubectl
+//     delete's "No resources found" line on empty match).
 //
-// Accidental loosening of either would silently swallow a
-// genuine bug or noise up the user-facing output.
-func TestApplySteps_TolerateContract(t *testing.T) {
-	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k"})
+// Loosening either silently swallows a real bug or noises up
+// the user-facing output.
+func TestApplyGroups_TolerateContract(t *testing.T) {
+	groups := applyGroups(Options{Context: "local", KustomizeDir: "/tmp/k"})
 
-	wantStderr := [][]string{
-		{"AlreadyExists", "no objects passed to create"}, // create
-		nil,                                               // delete (none on stderr)
-		{"no objects passed to apply"},                   // serverside-force
-		{"no objects passed to apply"},                   // serverside
-		{"no objects passed to apply"},                   // plain apply
+	type pair struct {
+		stderr []string
+		stdout []string
 	}
-	wantStdout := [][]string{
-		nil,                       // create
-		{"No resources found"},    // delete
-		nil, nil, nil,             // apply variants
+	want := [][]pair{
+		// create
+		{
+			{stderr: []string{"AlreadyExists", "no objects passed to create"}},
+		},
+		// replace: delete + apply
+		{
+			{stdout: []string{"No resources found"}},
+			{stderr: []string{"no objects passed to apply"}},
+		},
+		// serverside-force
+		{
+			{stderr: []string{"no objects passed to apply"}},
+		},
+		// serverside
+		{
+			{stderr: []string{"no objects passed to apply"}},
+		},
+		// default
+		{
+			{stderr: []string{"no objects passed to apply"}},
+		},
 	}
-	for i := range steps {
-		if !reflect.DeepEqual(steps[i].stderrTolerate, wantStderr[i]) {
-			t.Errorf("step %d stderrTolerate mismatch\n got:  %v\n want: %v",
-				i, steps[i].stderrTolerate, wantStderr[i])
+	for gi, g := range groups {
+		if len(g.invocations) != len(want[gi]) {
+			t.Errorf("group %d invocations: %d want %d", gi, len(g.invocations), len(want[gi]))
+			continue
 		}
-		if !reflect.DeepEqual(steps[i].stdoutSuppress, wantStdout[i]) {
-			t.Errorf("step %d stdoutSuppress mismatch\n got:  %v\n want: %v",
-				i, steps[i].stdoutSuppress, wantStdout[i])
+		for ii, inv := range g.invocations {
+			if !reflect.DeepEqual(inv.stderrTolerate, want[gi][ii].stderr) {
+				t.Errorf("group %d (mode=%q) inv %d stderrTolerate: got %v want %v",
+					gi, g.mode, ii, inv.stderrTolerate, want[gi][ii].stderr)
+			}
+			if !reflect.DeepEqual(inv.stdoutSuppress, want[gi][ii].stdout) {
+				t.Errorf("group %d (mode=%q) inv %d stdoutSuppress: got %v want %v",
+					gi, g.mode, ii, inv.stdoutSuppress, want[gi][ii].stdout)
+			}
 		}
 	}
 }

--- a/pkg/yconverge/kubectl_test.go
+++ b/pkg/yconverge/kubectl_test.go
@@ -110,23 +110,44 @@ func TestApplySteps_NoDryRunByDefault(t *testing.T) {
 }
 
 // TestApplySteps_TolerateContract pins the per-step "expected
-// empty / idempotent" stderr substrings. The bash plugin
-// distinguishes which kubectl errors are the documented
-// converge-mode happy path (empty selector match, AlreadyExists
-// on a re-create) from a real failure -- accidental loosening
-// of these would silently swallow a genuine bug.
+// empty / idempotent" output substrings, split between the two
+// channels kubectl uses:
+//
+//   - stderrTolerate: stderr substrings that, together with a
+//     non-zero exit, count as success. Used for the apply / create
+//     "no objects passed to <verb>" empty-selector case and for
+//     create's AlreadyExists re-run case.
+//   - stdoutSuppress: stdout substrings that, when produced by an
+//     otherwise successful kubectl run, are dropped before
+//     forwarding to the user. Used for `kubectl delete`'s
+//     "No resources found" line on empty match (delete prints
+//     this to stdout, not stderr, with exit 0).
+//
+// Accidental loosening of either would silently swallow a
+// genuine bug or noise up the user-facing output.
 func TestApplySteps_TolerateContract(t *testing.T) {
 	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k"})
-	want := [][]string{
+
+	wantStderr := [][]string{
 		{"AlreadyExists", "no objects passed to create"}, // create
-		{"No resources found"},                           // delete
+		nil,                                               // delete (none on stderr)
 		{"no objects passed to apply"},                   // serverside-force
 		{"no objects passed to apply"},                   // serverside
 		{"no objects passed to apply"},                   // plain apply
 	}
-	for i, w := range want {
-		if !reflect.DeepEqual(steps[i].tolerate, w) {
-			t.Errorf("step %d tolerate mismatch\n got:  %v\n want: %v", i, steps[i].tolerate, w)
+	wantStdout := [][]string{
+		nil,                       // create
+		{"No resources found"},    // delete
+		nil, nil, nil,             // apply variants
+	}
+	for i := range steps {
+		if !reflect.DeepEqual(steps[i].stderrTolerate, wantStderr[i]) {
+			t.Errorf("step %d stderrTolerate mismatch\n got:  %v\n want: %v",
+				i, steps[i].stderrTolerate, wantStderr[i])
+		}
+		if !reflect.DeepEqual(steps[i].stdoutSuppress, wantStdout[i]) {
+			t.Errorf("step %d stdoutSuppress mismatch\n got:  %v\n want: %v",
+				i, steps[i].stdoutSuppress, wantStdout[i])
 		}
 	}
 }

--- a/pkg/yconverge/kubectl_test.go
+++ b/pkg/yconverge/kubectl_test.go
@@ -1,0 +1,132 @@
+package yconverge
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestApplySteps_OrderAndCount: the bash plugin runs five
+// label-routed kubectl invocations in a fixed order. Pin the
+// order here so a refactor that reshuffles them (or drops the
+// fall-through plain-apply step) fails loudly.
+func TestApplySteps_OrderAndCount(t *testing.T) {
+	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k"})
+	if len(steps) != 5 {
+		t.Fatalf("want 5 steps, got %d", len(steps))
+	}
+
+	// Step ordering, asserted on the first verb-ish token after
+	// --context=... so the test stays stable if a flag's order
+	// inside one step shifts.
+	wantVerbs := []string{"create", "delete", "apply", "apply", "apply"}
+	for i, want := range wantVerbs {
+		if got := steps[i].args[1]; got != want {
+			t.Errorf("step %d: verb %q, want %q (full args: %v)", i, got, want, steps[i].args)
+		}
+	}
+}
+
+// TestApplySteps_PerStepArgs locks the exact argv each step
+// produces for a vanilla (non-dry-run) Options. This is the
+// regression guard for the converge-mode contract: any drift
+// in `--save-config`, `--server-side`, `--force-conflicts`,
+// `--field-manager=y-cluster`, or the selector formula
+// surfaces as a test failure rather than as silent semantic
+// change against the cluster.
+func TestApplySteps_PerStepArgs(t *testing.T) {
+	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k"})
+	want := [][]string{
+		{
+			"--context=local", "create", "--save-config",
+			"--selector=yolean.se/converge-mode=create",
+			"-k", "/tmp/k",
+		},
+		{
+			"--context=local", "delete",
+			"--selector=yolean.se/converge-mode=replace",
+			"-k", "/tmp/k",
+		},
+		{
+			"--context=local", "apply",
+			"--server-side", "--force-conflicts", "--field-manager=y-cluster",
+			"--selector=yolean.se/converge-mode=serverside-force",
+			"-k", "/tmp/k",
+		},
+		{
+			"--context=local", "apply",
+			"--server-side", "--field-manager=y-cluster",
+			"--selector=yolean.se/converge-mode=serverside",
+			"-k", "/tmp/k",
+		},
+		{
+			"--context=local", "apply",
+			"--selector=yolean.se/converge-mode!=create," +
+				"yolean.se/converge-mode!=serverside," +
+				"yolean.se/converge-mode!=serverside-force",
+			"-k", "/tmp/k",
+		},
+	}
+	for i, w := range want {
+		if !reflect.DeepEqual(steps[i].args, w) {
+			t.Errorf("step %d args mismatch\n got:  %v\n want: %v", i, steps[i].args, w)
+		}
+	}
+}
+
+// TestApplySteps_DryRunForwards: --dry-run=server must reach
+// every step (delete + create + apply variants), so a dry-run of
+// a kustomization with replace-mode resources is provably
+// non-mutating end-to-end -- the bash plugin's behaviour.
+func TestApplySteps_DryRunForwards(t *testing.T) {
+	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k", DryRun: "server"})
+	for i, s := range steps {
+		found := false
+		for _, a := range s.args {
+			if a == "--dry-run=server" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("step %d (verb=%s) missing --dry-run=server: %v", i, s.args[1], s.args)
+		}
+	}
+}
+
+// TestApplySteps_NoDryRunByDefault confirms the inverse: an
+// empty Options.DryRun must not insert --dry-run=anything.
+// Catches a typo where a default value (e.g. "none") gets
+// forwarded as a flag.
+func TestApplySteps_NoDryRunByDefault(t *testing.T) {
+	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k"})
+	for i, s := range steps {
+		for _, a := range s.args {
+			if strings.HasPrefix(a, "--dry-run=") {
+				t.Errorf("step %d unexpectedly carries %q: %v", i, a, s.args)
+			}
+		}
+	}
+}
+
+// TestApplySteps_TolerateContract pins the per-step "expected
+// empty / idempotent" stderr substrings. The bash plugin
+// distinguishes which kubectl errors are the documented
+// converge-mode happy path (empty selector match, AlreadyExists
+// on a re-create) from a real failure -- accidental loosening
+// of these would silently swallow a genuine bug.
+func TestApplySteps_TolerateContract(t *testing.T) {
+	steps := applySteps(Options{Context: "local", KustomizeDir: "/tmp/k"})
+	want := [][]string{
+		{"AlreadyExists", "no objects passed to create"}, // create
+		{"No resources found"},                           // delete
+		{"no objects passed to apply"},                   // serverside-force
+		{"no objects passed to apply"},                   // serverside
+		{"no objects passed to apply"},                   // plain apply
+	}
+	for i, w := range want {
+		if !reflect.DeepEqual(steps[i].tolerate, w) {
+			t.Errorf("step %d tolerate mismatch\n got:  %v\n want: %v", i, steps[i].tolerate, w)
+		}
+	}
+}

--- a/pkg/yconverge/yconverge.go
+++ b/pkg/yconverge/yconverge.go
@@ -3,6 +3,8 @@ package yconverge
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 
 	"go.uber.org/zap"
@@ -18,6 +20,22 @@ type Options struct {
 	ChecksOnly   bool   // skip apply, run checks only
 	PrintDeps    bool   // print dependency order and exit
 	SkipChecks   bool   // skip checks after apply
+
+	// Stdout is where user-facing progress and forwarded kubectl
+	// output is written. nil -> os.Stdout. Tests pass a buffer to
+	// capture; the CLI leaves it nil. Distinct from the zap logger
+	// (which is the diagnostic channel on stderr) -- this writer
+	// is the command's UI, like kubectl's own per-resource lines.
+	Stdout io.Writer
+}
+
+// progressOut returns the writer the four "yconverge ..." headers
+// and the forwarded kubectl stdout share. Always non-nil.
+func (o Options) progressOut() io.Writer {
+	if o.Stdout != nil {
+		return o.Stdout
+	}
+	return os.Stdout
 }
 
 // Result holds the outcome of a yconverge run.
@@ -86,15 +104,16 @@ func Run(ctx context.Context, opts Options, logger *zap.Logger) (*Result, error)
 
 	// Multi-step: if more than one step, each step before the last
 	// is a dependency that gets its own full convergence cycle.
-	if len(steps) > 1 {
+	hasDeps := len(steps) > 1
+	if hasDeps {
 		logger.Debug("converge plan",
 			zap.String("context", opts.Context),
 			zap.Int("steps", len(steps)),
 		)
 		for _, step := range steps[:len(steps)-1] {
-			logger.Debug("converge dependency",
-				zap.String("dir", RelPath(cueRoot, step)),
-			)
+			rel := RelPath(cueRoot, step)
+			logger.Debug("converge dependency", zap.String("dir", rel))
+			fmt.Fprintf(opts.progressOut(), "yconverge dependency %s\n", rel)
 			depOpts := Options{
 				Context:      opts.Context,
 				KustomizeDir: step,
@@ -104,18 +123,22 @@ func Run(ctx context.Context, opts Options, logger *zap.Logger) (*Result, error)
 				// verify a whole chain without applying anywhere.
 				// Earlier this field was dropped, so deps re-applied
 				// even when the user only wanted a health check.
-				ChecksOnly:   opts.ChecksOnly,
+				ChecksOnly: opts.ChecksOnly,
+				Stdout:     opts.Stdout,
 			}
 			if _, err := convergeSingle(ctx, depOpts, logger); err != nil {
-				return nil, fmt.Errorf("dependency %s: %w", RelPath(cueRoot, step), err)
+				return nil, fmt.Errorf("dependency %s: %w", rel, err)
 			}
 		}
 	}
 
-	// Final step: the target itself
-	logger.Debug("converge target",
-		zap.String("dir", RelPath(cueRoot, absDir)),
-	)
+	// Final step: the target itself. Emit a "target" header only
+	// when at least one dep ran -- a no-dep run doesn't need a
+	// header for what the user explicitly passed via -k.
+	logger.Debug("converge target", zap.String("dir", RelPath(cueRoot, absDir)))
+	if hasDeps {
+		fmt.Fprintf(opts.progressOut(), "yconverge target %s\n", RelPath(cueRoot, absDir))
+	}
 	if _, err := convergeSingle(ctx, opts, logger); err != nil {
 		return nil, err
 	}
@@ -159,6 +182,7 @@ func convergeSingle(ctx context.Context, opts Options, logger *zap.Logger) (*Res
 			Context:   opts.Context,
 			Namespace: namespace,
 			Logger:    logger,
+			Stdout:    opts.progressOut(),
 		}
 		for _, cueDir := range cueDirs {
 			checks, err := ParseChecks(cueDir)

--- a/pkg/yconverge/yconverge.go
+++ b/pkg/yconverge/yconverge.go
@@ -148,7 +148,7 @@ func convergeSingle(ctx context.Context, opts Options, logger *zap.Logger) (*Res
 
 	// Apply (unless checks-only)
 	if !opts.ChecksOnly {
-		if err := applyStep(ctx, opts, logger); err != nil {
+		if err := runApply(ctx, opts, logger); err != nil {
 			return nil, fmt.Errorf("apply %s: %w", opts.KustomizeDir, err)
 		}
 	}
@@ -177,12 +177,12 @@ func convergeSingle(ctx context.Context, opts Options, logger *zap.Logger) (*Res
 	return &Result{Steps: []string{absDir}}, nil
 }
 
-// applyStep wraps the shellout to `kubectl apply` in the package's
+// runApply wraps the shellout to `kubectl apply` in the package's
 // kubectl.go helper, with one extra responsibility: emit a debug
 // log of what's being applied so `-v` runs trace what each
 // dependency-walk step is doing without the user having to
 // correlate kubectl invocations to the dep graph manually.
-func applyStep(ctx context.Context, opts Options, logger *zap.Logger) error {
+func runApply(ctx context.Context, opts Options, logger *zap.Logger) error {
 	logger.Debug("apply",
 		zap.String("context", opts.Context),
 		zap.String("kustomizeDir", opts.KustomizeDir),

--- a/pkg/yconverge/yconverge.go
+++ b/pkg/yconverge/yconverge.go
@@ -88,12 +88,12 @@ func Run(ctx context.Context, opts Options, logger *zap.Logger) (*Result, error)
 	// Multi-step: if more than one step, each step before the last
 	// is a dependency that gets its own full convergence cycle.
 	if len(steps) > 1 {
-		logger.Info("converge plan",
+		logger.Debug("converge plan",
 			zap.String("context", opts.Context),
 			zap.Int("steps", len(steps)),
 		)
 		for _, step := range steps[:len(steps)-1] {
-			logger.Info("converge dependency",
+			logger.Debug("converge dependency",
 				zap.String("dir", RelPath(cueRoot, step)),
 			)
 			depOpts := Options{
@@ -114,7 +114,7 @@ func Run(ctx context.Context, opts Options, logger *zap.Logger) (*Result, error)
 	}
 
 	// Final step: the target itself
-	logger.Info("converge target",
+	logger.Debug("converge target",
 		zap.String("dir", RelPath(cueRoot, absDir)),
 	)
 	if _, err := convergeSingle(ctx, opts, logger); err != nil {

--- a/pkg/yconverge/yconverge.go
+++ b/pkg/yconverge/yconverge.go
@@ -7,7 +7,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/Yolean/y-cluster/pkg/k8sapply"
 	"github.com/Yolean/y-cluster/pkg/kustomize/traverse"
 )
 
@@ -149,7 +148,7 @@ func convergeSingle(ctx context.Context, opts Options, logger *zap.Logger) (*Res
 
 	// Apply (unless checks-only)
 	if !opts.ChecksOnly {
-		if err := kubectlApply(ctx, opts, logger); err != nil {
+		if err := applyStep(ctx, opts, logger); err != nil {
 			return nil, fmt.Errorf("apply %s: %w", opts.KustomizeDir, err)
 		}
 	}
@@ -178,26 +177,18 @@ func convergeSingle(ctx context.Context, opts Options, logger *zap.Logger) (*Res
 	return &Result{Steps: []string{absDir}}, nil
 }
 
-// kubectlApply runs server-side apply against the named context's
-// cluster, equivalent to:
-//
-//	kubectl --context=<...> apply --server-side --force-conflicts \
-//	  --field-manager=y-cluster -k <KustomizeDir>
-//
-// Implemented in pkg/k8sapply via client-go directly so callers
-// get typed errors (apierrors.IsConflict, IsForbidden, etc.)
-// instead of "exit status 1, see stderr".
-func kubectlApply(ctx context.Context, opts Options, logger *zap.Logger) error {
-	dryRun := k8sapply.DryRunNone
-	if opts.DryRun == "server" {
-		dryRun = k8sapply.DryRunServer
-	}
+// applyStep wraps the shellout to `kubectl apply` in the package's
+// kubectl.go helper, with one extra responsibility: emit a debug
+// log of what's being applied so `-v` runs trace what each
+// dependency-walk step is doing without the user having to
+// correlate kubectl invocations to the dep graph manually.
+func applyStep(ctx context.Context, opts Options, logger *zap.Logger) error {
 	logger.Debug("apply",
 		zap.String("context", opts.Context),
 		zap.String("kustomizeDir", opts.KustomizeDir),
-		zap.String("dryRun", string(dryRun)),
+		zap.String("dryRun", opts.DryRun),
 	)
-	if err := k8sapply.Apply(ctx, opts.Context, opts.KustomizeDir, dryRun, logger); err != nil {
+	if err := kubectlApply(ctx, opts); err != nil {
 		return fmt.Errorf("apply %s: %w", opts.KustomizeDir, err)
 	}
 	return nil


### PR DESCRIPTION
Reintroduces behavior from the bash kubectl-yconverge impl + adds dependency and checks output.